### PR TITLE
Add SQLite persistence for benchmarks (#1)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,78 +1,46 @@
-# Backend Service
+# Backend — SQLite Persistence
 
-## 📌 Overview
+Async SQLite persistence layer for template benchmark records.
 
-This is a simple monolithic web service responsible for storing and retrieving template rendering benchmark results.
+## Stack
 
-The service exposes two HTTP endpoints:
+- Python 3.11+
+- aiosqlite
 
-* `POST /benchmarks` — store benchmark result
-* `GET /benchmarks` — retrieve stored results
+## Setup
 
-The goal is to keep the implementation minimal and focused, without overengineering (no strict layering).
-
----
-
-## 🧠 Data Model
-
-Each record contains:
-
-* `template_engine` (string) — name of the templating engine
-* `render_time_ms` (float) — rendering time in milliseconds
-* `payload` (string/json) — optional input data used for rendering
-
----
-
-## ⚙️ Tech Stack
-
-* Python
-* Flask (or similar lightweight framework)
-* SQLite (default storage)
-
----
-
-## 📡 API Contract
-
-### POST /benchmarks
-
-Store a benchmark result.
-
-**Request body (JSON):**
-
-```json
-{
-  "template_engine": "jinja2",
-  "render_time_ms": 12.5,
-  "payload": "{ \"data\": 123 }"
-}
+```bash
+pip install -r requirements.txt
 ```
 
-**Response:**
+## Database
 
-```json
-{
-  "status": "ok"
-}
+SQLite file `benchmarks.db`, created automatically on first run.
+
+Schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS benchmarks (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    template_engine TEXT    NOT NULL,
+    render_time_ms  TEXT    NOT NULL,
+    payload         TEXT    NOT NULL,
+    created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+);
 ```
 
----
+> `render_time_ms` — TEXT, чтобы сохранить формат `"2.000"`.
 
-### GET /results
+## API (db.py)
 
-Retrieve stored results.
+```python
+await init_db()                                          # создать таблицу
+await insert_benchmark(engine, render_time_ms, payload)  # сохранить запись
+await get_benchmarks()                                   # получить все записи (новые первыми)
+```
 
-**Query params (optional):**
+## Tests
 
-* `template_engine`
-
-**Response:**
-
-```json
-[
-  {
-    "template_engine": "jinja2",
-    "render_time_ms": 12.5,
-    "payload": "..."
-  }
-]
+```bash
+pytest
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,19 +1,85 @@
-# Backend — SQLite Persistence
+# Backend Service
 
-Async SQLite persistence layer for template benchmark records.
+## 📌 Overview
 
-## Stack
+This is a simple monolithic web service responsible for storing and retrieving template rendering benchmark results.
 
-- Python 3.11+
-- aiosqlite
+The service exposes two HTTP endpoints:
 
-## Setup
+* `POST /benchmarks` — store benchmark result
+* `GET /benchmarks` — retrieve stored results
 
-```bash
-pip install -r requirements.txt
+The goal is to keep the implementation minimal and focused, without overengineering (no strict layering).
+
+---
+
+## 🧠 Data Model
+
+Each record contains:
+
+* `template_engine` (string) — name of the templating engine
+* `render_time_ms` (float) — rendering time in milliseconds
+* `payload` (string/json) — optional input data used for rendering
+
+---
+
+## ⚙️ Tech Stack
+
+* Python
+* Flask (or similar lightweight framework)
+* SQLite (default storage)
+
+---
+
+## 📡 API Contract
+
+### POST /benchmarks
+
+Store a benchmark result.
+
+**Request body (JSON):**
+
+```json
+{
+  "template_engine": "jinja2",
+  "render_time_ms": 12.5,
+  "payload": "{ \"data\": 123 }"
+}
 ```
 
-## Database
+**Response:**
+
+```json
+{
+  "status": "ok"
+}
+```
+
+---
+
+### GET /results
+
+Retrieve stored results.
+
+**Query params (optional):**
+
+* `template_engine`
+
+**Response:**
+
+```json
+[
+  {
+    "template_engine": "jinja2",
+    "render_time_ms": 12.5,
+    "payload": "..."
+  }
+]
+```
+
+---
+
+## 🗄️ Database
 
 SQLite file `benchmarks.db`, created automatically on first run.
 
@@ -29,9 +95,9 @@ CREATE TABLE IF NOT EXISTS benchmarks (
 );
 ```
 
-> `render_time_ms` — TEXT, чтобы сохранить формат `"2.000"`.
+> `render_time_ms` хранится как TEXT, чтобы сохранить формат `"2.000"`.
 
-## API (db.py)
+### db.py
 
 ```python
 await init_db()                                          # создать таблицу
@@ -39,7 +105,15 @@ await insert_benchmark(engine, render_time_ms, payload)  # сохранить з
 await get_benchmarks()                                   # получить все записи (новые первыми)
 ```
 
-## Tests
+---
+
+## 🚀 Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## 🧪 Tests
 
 ```bash
 pytest

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,61 @@
+import aiosqlite
+
+DB_PATH = "benchmarks.db"
+
+
+async def init_db() -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                template_engine TEXT    NOT NULL,
+                render_time_ms  TEXT    NOT NULL,
+                payload         TEXT    NOT NULL,
+                created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+            )
+        """)
+        await db.commit()
+
+
+async def insert_benchmark(template_engine: str, render_time_ms: str, payload: str) -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "INSERT INTO benchmarks (template_engine, render_time_ms, payload) VALUES (?, ?, ?)",
+            (template_engine, render_time_ms, payload),
+        )
+        await db.commit()
+        row_id = cursor.lastrowid
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT id, template_engine, render_time_ms, payload, created_at FROM benchmarks WHERE id = ?",
+            (row_id,),
+        ) as cur:
+            row = await cur.fetchone()
+
+    return {
+        "id": row[0],
+        "template_engine": row[1],
+        "render_time_ms": row[2],
+        "payload": row[3],
+        "created_at": row[4],
+    }
+
+
+async def get_benchmarks() -> list:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT id, template_engine, render_time_ms, payload, created_at FROM benchmarks ORDER BY id DESC"
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+    return [
+        {
+            "id": row[0],
+            "template_engine": row[1],
+            "render_time_ms": row[2],
+            "payload": row[3],
+            "created_at": row[4],
+        }
+        for row in rows
+    ]

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,9 +1,22 @@
+"""Async SQLite persistence layer for benchmark records."""
+
+from typing import TypedDict
+
 import aiosqlite
 
 DB_PATH = "benchmarks.db"
 
 
+class BenchmarkRecord(TypedDict):
+    id: int
+    template_engine: str
+    render_time_ms: str
+    payload: str
+    created_at: str
+
+
 async def init_db() -> None:
+    """Create the benchmarks table if it does not exist."""
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks (
@@ -17,7 +30,22 @@ async def init_db() -> None:
         await db.commit()
 
 
-async def insert_benchmark(template_engine: str, render_time_ms: str, payload: str) -> dict:
+async def insert_benchmark(
+    template_engine: str,
+    render_time_ms: str,
+    payload: str,
+) -> BenchmarkRecord:
+    """Insert a benchmark record and return the saved row.
+
+    Args:
+        template_engine: Name of the template engine (e.g. "mustache").
+        render_time_ms:  Render time as a formatted string (e.g. "2.000").
+                         Stored as TEXT to preserve trailing zeros.
+        payload:         JSON string with the data used during rendering.
+
+    Returns:
+        The newly created record including auto-generated id and created_at.
+    """
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             "INSERT INTO benchmarks (template_engine, render_time_ms, payload) VALUES (?, ?, ?)",
@@ -28,34 +56,37 @@ async def insert_benchmark(template_engine: str, render_time_ms: str, payload: s
 
     async with aiosqlite.connect(DB_PATH) as db:
         async with db.execute(
-            "SELECT id, template_engine, render_time_ms, payload, created_at FROM benchmarks WHERE id = ?",
+            "SELECT id, template_engine, render_time_ms, payload, created_at"
+            " FROM benchmarks WHERE id = ?",
             (row_id,),
         ) as cur:
             row = await cur.fetchone()
 
-    return {
-        "id": row[0],
-        "template_engine": row[1],
-        "render_time_ms": row[2],
-        "payload": row[3],
-        "created_at": row[4],
-    }
+    return BenchmarkRecord(
+        id=row[0],
+        template_engine=row[1],
+        render_time_ms=row[2],
+        payload=row[3],
+        created_at=row[4],
+    )
 
 
-async def get_benchmarks() -> list:
+async def get_benchmarks() -> list[BenchmarkRecord]:
+    """Return all benchmark records ordered from newest to oldest."""
     async with aiosqlite.connect(DB_PATH) as db:
         async with db.execute(
-            "SELECT id, template_engine, render_time_ms, payload, created_at FROM benchmarks ORDER BY id DESC"
+            "SELECT id, template_engine, render_time_ms, payload, created_at"
+            " FROM benchmarks ORDER BY id DESC"
         ) as cursor:
             rows = await cursor.fetchall()
 
     return [
-        {
-            "id": row[0],
-            "template_engine": row[1],
-            "render_time_ms": row[2],
-            "payload": row[3],
-            "created_at": row[4],
-        }
+        BenchmarkRecord(
+            id=row[0],
+            template_engine=row[1],
+            render_time_ms=row[2],
+            payload=row[3],
+            created_at=row[4],
+        )
         for row in rows
     ]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
-flask
-sqlite3
+aiosqlite
+pytest
+pytest-asyncio

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
+flask[async]
+flask-cors
 aiosqlite
 pytest
 pytest-asyncio

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,62 @@
+import os
+
+import aiosqlite
+import pytest
+
+import db as db_module
+from db import get_benchmarks, init_db, insert_benchmark
+
+TEST_DB = "test_benchmarks.db"
+
+
+@pytest.fixture(autouse=True)
+def use_test_db(monkeypatch, tmp_path):
+    test_path = str(tmp_path / "test.db")
+    monkeypatch.setattr(db_module, "DB_PATH", test_path)
+    yield
+
+
+async def test_init_db_creates_table():
+    await init_db()
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='benchmarks'"
+        ) as cur:
+            row = await cur.fetchone()
+    assert row is not None
+
+
+async def test_insert_returns_record():
+    await init_db()
+    record = await insert_benchmark("mustache", "2.000", '{"name": "Alice"}')
+
+    assert record["id"] == 1
+    assert record["template_engine"] == "mustache"
+    assert record["render_time_ms"] == "2.000"
+    assert record["payload"] == '{"name": "Alice"}'
+    assert "created_at" in record
+
+
+async def test_render_time_stored_as_text():
+    await init_db()
+    await insert_benchmark("ejs", "2.000", "{}")
+    records = await get_benchmarks()
+
+    assert records[0]["render_time_ms"] == "2.000"
+
+
+async def test_get_benchmarks_returns_newest_first():
+    await init_db()
+    await insert_benchmark("jinja2", "1.000", "{}")
+    await insert_benchmark("ejs", "3.000", "{}")
+    records = await get_benchmarks()
+
+    assert len(records) == 2
+    assert records[0]["template_engine"] == "ejs"
+    assert records[1]["template_engine"] == "jinja2"
+
+
+async def test_get_benchmarks_empty():
+    await init_db()
+    records = await get_benchmarks()
+    assert records == []


### PR DESCRIPTION
## Summary
- `db.py`: async функции `init_db`, `insert_benchmark`, `get_benchmarks` через `aiosqlite`
- `render_time_ms` хранится как TEXT — формат `"2.000"` не теряется
- БД создаётся автоматически при первом запуске, данные переживают рестарт
- 5 unit-тестов (pytest-asyncio): init, insert, формат, порядок, пустой список

Closes #1