### PR TITLE
Add Render deployment configuration

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/TemplateProfiler.iml
+++ b/.idea/TemplateProfiler.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/TemplateProfiler.iml" filepath="$PROJECT_DIR$/.idea/TemplateProfiler.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.renderignore
+++ b/.renderignore
@@ -1,0 +1,6 @@
+frontend/
+.idea/
+.git/
+*.md
+LICENSE
+!backend/

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: template-profiler-backend
+    env: python
+    region: frankfurt
+    plan: free
+    rootDir: backend
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.0


### PR DESCRIPTION
Added deployment configuration for the backend service to Render.

Changes:
`render.yaml` — Render Blueprint configuration (web service, Python env, uvicorn startup)
`.renderignore` — excludes frontend/, .idea/, .git/ from deployment

All 23 tests pass
GET /benchmarks/ returns results
POST /benchmarks/ creates benchmark records
Service deployed and accessible at https://template-profiler-backend.onrender.com/

<img width="695" height="107" alt="Снимок экрана 2026-04-06 210811" src="https://github.com/user-attachments/assets/f4c4e979-da51-404e-b920-0911d1f963f1" />

